### PR TITLE
return 0 when calling function usage() passing an empty array as readings

### DIFF
--- a/src/usage/usage.js
+++ b/src/usage/usage.js
@@ -6,6 +6,9 @@ const average = (readings) => {
 };
 
 const timeElapsedInHours = (readings) => {
+    if(readings.length <= 0) {
+        return 0;
+    }
     readings.sort((a, b) => a.time - b.time);
     const seconds = readings[readings.length - 1].time - readings[0].time;
     const hours = Math.floor(seconds / 3600);

--- a/src/usage/usage.js
+++ b/src/usage/usage.js
@@ -16,7 +16,11 @@ const timeElapsedInHours = (readings) => {
 };
 
 const usage = (readings) => {
-    return average(readings) / timeElapsedInHours(readings);
+    const timeElapsed = timeElapsedInHours(readings);
+    if(timeElapsed === 0) {
+        return 0;
+    }
+    return average(readings) / timeElapsed;
 };
 
 const usageCost = (readings, rate) => {

--- a/src/usage/usage.test.js
+++ b/src/usage/usage.test.js
@@ -24,6 +24,12 @@ describe("usage", () => {
         expect(averageMeter0).toBe(0.26785);
     });
 
+    it("should return 0 when timeElapsedInHours get empty readings", () => {
+        const timeElapsed = timeElapsedInHours([]);
+
+        expect(timeElapsed).toEqual(0);
+    })
+
     it("should get time elapsed in hours for all readings for a meter", () => {
         const { getReadings } = readings({
             [meters.METER0]: [

--- a/src/usage/usage.test.js
+++ b/src/usage/usage.test.js
@@ -10,6 +10,13 @@ const {
 } = require("./usage");
 
 describe("usage", () => {
+
+    it("should return 0 when usage get empty readings", () => {
+        const usageMeter = usage([]);
+
+        expect(usageMeter).toEqual(0);
+    })
+
     it("should average all readings for a meter", () => {
         const { getReadings } = readings({
             [meters.METER0]: [


### PR DESCRIPTION
I accidentally encounter an error while doing pair programming.
When calling function `usage([])` given empty array.
It throws an error.

```js
    TypeError: Cannot read property 'time' of undefined

       9 | 
      10 |     readings.sort((a, b) => a.time - b.time);
    > 11 |     const seconds = readings[readings.length - 1].time - readings[0].time;
         |                                                   ^
      12 |     const hours = Math.floor(seconds / 3600);
      13 |     return hours;
      14 | };
```

Because `usage` pass readings to `timeElapsedInHours`  that doesn't expect an empty array.

This PR handle a case for empty array and have `usage` and `timeElapsedInHours` return 0 instead of throwing an error.