### PR TITLE
Fix a bug for /recommend and /compare-all endpoints

### DIFF
--- a/src/price-plans/price-plans-controller.js
+++ b/src/price-plans/price-plans-controller.js
@@ -3,11 +3,21 @@ const { usageForAllPricePlans } = require("../usage/usage");
 
 const recommend = (getReadings, req) => {
     const meter = req.params.smartMeterId;
-    return usageForAllPricePlans(pricePlans, getReadings(meter));
+    const pricePlanComparisons = usageForAllPricePlans(pricePlans, getReadings(meter)).sort((a, b) => extractCost(a) - extractCost(b))
+    if("limit" in req.params) {
+        return pricePlanComparisons.slice(0, req.params.limit);
+    }
+    return pricePlanComparisons;
 };
 
+const extractCost = (cost) => {
+    const [, value] = Object.entries(cost).find( ([key]) => key in pricePlans)
+    return value
+}
+
 const compare = (getData, req) => {
-    const pricePlanComparisons = recommend(getData, req);
+    const meter = req.params.smartMeterId;
+    const pricePlanComparisons = usageForAllPricePlans(pricePlans, getData(meter));;
     return {
         smartMeterId: req.params.smartMeterId,
         pricePlanComparisons,

--- a/src/price-plans/price-plans-controller.test.js
+++ b/src/price-plans/price-plans-controller.test.js
@@ -1,10 +1,43 @@
 const { meters } = require("../meters/meters");
 const { pricePlanNames } = require("./price-plans");
 const { readings } = require("../readings/readings");
-const { recommend } = require("./price-plans-controller");
+const { compare, recommend } = require("./price-plans-controller");
 
 describe("price plans", () => {
-    it("should get usage cost for all price plans", () => {
+    it("should compare usage cost for all price plans", () => {
+        const { getReadings } = readings({
+            [meters.METER0]: [
+                { time: 1607686125, reading: 0.26785 },
+                { time: 1607599724, reading: 0.26785 },
+                { time: 1607513324, reading: 0.26785 },
+            ],
+        });
+
+        const expected = {
+            pricePlanComparisons: [
+                {
+                    [pricePlanNames.PRICEPLAN0]: 0.26785 / 48 * 10,
+                },
+                {
+                    [pricePlanNames.PRICEPLAN1]: 0.26785 / 48 * 2,
+                },
+                {
+                    [pricePlanNames.PRICEPLAN2]: 0.26785 / 48 * 1,
+                },
+            ],
+            smartMeterId: meters.METER0
+        };
+
+        const recommendation = compare(getReadings, {
+            params: {
+                smartMeterId: meters.METER0,
+            },
+        });
+
+        expect(recommendation).toEqual(expected);
+    });
+
+    it("should recommend usage cost for all price plans by ordering from cheapest to expensive", () => {
         const { getReadings } = readings({
             [meters.METER0]: [
                 { time: 1607686125, reading: 0.26785 },
@@ -15,19 +48,47 @@ describe("price plans", () => {
 
         const expected = [
             {
-                [pricePlanNames.PRICEPLAN0]: 0.26785 / 48 * 10,
+                [pricePlanNames.PRICEPLAN2]: 0.26785 / 48 * 1,
             },
             {
                 [pricePlanNames.PRICEPLAN1]: 0.26785 / 48 * 2,
             },
             {
-                [pricePlanNames.PRICEPLAN2]: 0.26785 / 48 * 1,
+                [pricePlanNames.PRICEPLAN0]: 0.26785 / 48 * 10,
             },
         ];
 
         const recommendation = recommend(getReadings, {
             params: {
                 smartMeterId: meters.METER0,
+            },
+        });
+
+        expect(recommendation).toEqual(expected);
+    });
+
+    it("should limit recommendation", () => {
+        const { getReadings } = readings({
+            [meters.METER0]: [
+                { time: 1607686125, reading: 0.26785 },
+                { time: 1607599724, reading: 0.26785 },
+                { time: 1607513324, reading: 0.26785 },
+            ],
+        });
+
+        const expected = [
+            {
+                [pricePlanNames.PRICEPLAN2]: 0.26785 / 48 * 1,
+            },
+            {
+                [pricePlanNames.PRICEPLAN1]: 0.26785 / 48 * 2,
+            },
+        ];
+
+        const recommendation = recommend(getReadings, {
+            params: {
+                smartMeterId: meters.METER0,
+                limit: 2
             },
         });
 


### PR DESCRIPTION
To get the recommendations for a specific smart meter id, we have the following endpoint:
```
GET /price-plans/recommend/<smartMeterId>[?limit=<limit>]
```
We expect this endpoint to 
`(1)` return a list of usage costs per price plan *ordered by* the calculated cost. 
`(2)` use `limit` parameter to reduce the number of items in the list

But at the moment, we don't have the ordering and the `limit` parameter is ignored.

On the other hand, we have another endpoint that returns the usage costs calculated per price plans in no specific order:
```
GET /price-plans/compare-all/<smartMeterId>
```
And the expected response is formatted similar to:
```
{
  "smartMeterId": "smart-meter-0",
  "pricePlanComparisons": [
    { "price-plan-0": 0.0022953153900802437 },
    { "price-plan-1": 0.00045906307801604876 },
    { "price-plan-2": 0.00022953153900802438 }
  ]
}
```
Where as, at the moment it responds as:
```
[
    { "price-plan-0": 0.0022953153900802437 },
    { "price-plan-1": 0.00045906307801604876 },
    { "price-plan-2": 0.00022953153900802438 }
]
```