### PR TITLE
JOIJS [legndery] fix /recommend endpoint fetching the limit from query param

### DIFF
--- a/src/price-plans/price-plans-controller.js
+++ b/src/price-plans/price-plans-controller.js
@@ -4,8 +4,8 @@ const { usageForAllPricePlans } = require("../usage/usage");
 const recommend = (getReadings, req) => {
     const meter = req.params.smartMeterId;
     const pricePlanComparisons = usageForAllPricePlans(pricePlans, getReadings(meter)).sort((a, b) => extractCost(a) - extractCost(b))
-    if("limit" in req.params) {
-        return pricePlanComparisons.slice(0, req.params.limit);
+    if("limit" in req.query) {
+        return pricePlanComparisons.slice(0, req.query.limit);
     }
     return pricePlanComparisons;
 };

--- a/src/price-plans/price-plans-controller.test.js
+++ b/src/price-plans/price-plans-controller.test.js
@@ -32,6 +32,7 @@ describe("price plans", () => {
             params: {
                 smartMeterId: meters.METER0,
             },
+            query: {}
         });
 
         expect(recommendation).toEqual(expected);
@@ -62,6 +63,7 @@ describe("price plans", () => {
             params: {
                 smartMeterId: meters.METER0,
             },
+            query: {}
         });
 
         expect(recommendation).toEqual(expected);
@@ -88,8 +90,10 @@ describe("price plans", () => {
         const recommendation = recommend(getReadings, {
             params: {
                 smartMeterId: meters.METER0,
-                limit: 2
             },
+            query: {
+                limit: 2
+            }
         });
 
         expect(recommendation).toEqual(expected);


### PR DESCRIPTION
The `limit` of `/recommend` endpoint was being checked from path parameters, this PR changes that so that `limit` is checked from req.query instead of req.param.

Note: the `query` is added in test cases because in express the `req.query` is always present and otherwise the `in` operator would throw error.